### PR TITLE
fix: ensure pandas 3.0 compatibility for string dtype and openpyxl

### DIFF
--- a/data.py
+++ b/data.py
@@ -1208,7 +1208,7 @@ class DataInspector:
 			except Exception:
 				pass
 		for col in df.columns:
-			if df[col].dtype == 'object':
+			if df[col].dtype == 'object' or pd.api.types.is_string_dtype(df[col].dtype):
 				df[col] = df[col].astype(str).str.replace('μ', 'u')
 				df[col] = df[col].apply(lambda x: self._replace_special_chars(x) if isinstance(x, str) else x)
 		df = self.normalize_column_names(df)
@@ -1322,7 +1322,7 @@ class DataInspector:
 			except Exception:
 				pass
 		for col in df.columns:
-			if df[col].dtype == 'object':
+			if df[col].dtype == 'object' or pd.api.types.is_string_dtype(df[col].dtype):
 				df[col] = df[col].astype(str).str.replace('μ', 'u')
 				df[col] = df[col].apply(lambda x: self._replace_special_chars(x) if isinstance(x, str) else x)
 		df = self.normalize_column_names(df)

--- a/hits-preprocess.py
+++ b/hits-preprocess.py
@@ -1113,7 +1113,7 @@ class DataInspector:
 
         # Replace special characters in column values
         for col in df.columns:
-            if df[col].dtype == 'object':  # Only process string columns
+            if df[col].dtype == 'object' or pd.api.types.is_string_dtype(df[col].dtype):  # Only process string columns
                 # Replace μ (micro) with u
                 df[col] = df[col].astype(str).str.replace('μ', 'u')
                 # Replace other potentially problematic unicode characters

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ scikit-learn==1.6.1
 scipy==1.15.3
 matplotlib==3.10.3
 seaborn==0.13.2
-openpyxl>=3.0.0
+openpyxl>=3.1.5
 pint>=0.19.0
 omegaconf>=2.3.0
 


### PR DESCRIPTION
- Guard string-column processing with is_string_dtype() in addition to 'object' check, since pandas 3.0 defaults text columns to 'str' dtype (data.py, hits-preprocess.py). Prevents μ→u and special-char normalization from being silently skipped.
- Bump openpyxl pin to >=3.1.5 (pandas 3.0 read_excel requires >=3.1.0).