### PR TITLE
feat: v4.6 표준데이터포맷 대응 (갭 14건 수정)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,14 @@ input_data/Des_43404_PAMPA_Caco-2_MDCK_250829.xlsx
 processed_data/Des_43404_PAMPA_Caco-2_MDCK_250829_*
 processed_data/visualizations/Des_43404_PAMPA_Caco-2_MDCK_250829_*
 processed_data/splits/Des_43404_PAMPA_Caco-2_MDCK_250829_*
+
+# v4.6 rework: generated outputs and large/regenerable fixtures
+표준데이터포맷_v4.6.zip
+input_data/v46_fixtures/*.xlsx
+processed_data/*_gist_matrix*.csv
+processed_data/*_gist_matrix*.json
+processed_data/*_HumanPK.csv
+processed_data/*_unmapped.csv
+processed_data/*_processed.csv
+processed_data/splits/Solubility_data_*
+processed_data/splits/*_data_*

--- a/README.md
+++ b/README.md
@@ -3,6 +3,19 @@
 This repository contains a Python-based preprocessing pipeline for K-MELLODDY standard data format, primarily designed for tasks in ADME/T prediction. The pipeline supports SMILES standardization, outlier detection, feature scaling, label creation, and now includes multiprocessing support, data visualization, and machine learning-ready data splitting. It is suitable for classification and regression tasks.
 This repository will be updated when the K-MELLODDY standard data format is changed.
 
+## K-MELLODDY Standard Format v4.6 Support
+The pipeline was updated to fully support the **v4.6** standard data format (previously only ~25–30% was covered, with most v4.6 files producing empty/all-zero matrices or crashes). Highlights of the v4.6 adaptation:
+
+- **Column-name normalization**: case-insensitive canonicalization of `Measurement_*` (incl. the legacy `Measurment_*` typo), `Test_Subject*` (asterisk), `Test_Species → Test_Subject`, and VIVO's lowercase `Measurement_value`. The value column is preserved (the old `Unnamed:10` hard-coding is gone).
+- **Permeability**: `Measurement_Value(AtoB)` / `(BtoA)` bracket-list values (`[6,2]`, `[6,]`, `[,2]`) are parsed; AtoB feeds `Caco2`/`PAMPA` and `Efflux_ratio` is derived as `BtoA/AtoB`.
+- **Human PK**: wide-format, 3-row-header workbooks (`데이터1/2(Human PK)`) are detected and written to a separate `*_HumanPK.csv` (not a GIST-mappable schema) instead of crashing.
+- **pH sources**: pH is inferred from `Test_Subject` (`pH7.4`), `Measurement_Condition` (bare number), and `Test_Type`, in addition to dedicated pH columns.
+- **Units**: composite/exponent units are preserved — `10-6 cm/s` is no longer corrupted, molar units are case-sensitive (`uM` ≠ micrometre), and dimensionless units (`ratio`, `fold`, `%`) keep their value. Unparseable units are kept with a warning.
+- **Endpoint mapping**: exact CYP-isoform mapping (`CYP1A1`/`CYP2C8` have no GIST slot → left unmapped; `CYP3A4_MDZ`/`CYP3A4_TST` merge into `CYP3A4_Inhibitor`), whole-token matching so `tr`/`gr` no longer leak into `transporter`, and qualitative `Positive`/`Negative` (stored in `Measurement_Unit`) encoded as `1`/`0`.
+- **No silent loss**: rows whose endpoint has no GIST column (e.g. Cytotoxicity, Genetoxicity, pKa/MW, Phase-II metabolism) are reported and written to `*_unmapped.csv` (CLI) instead of being dropped silently.
+
+> ⚠️ Core classes (`UnitConverter`, `pHCorrector`, `DataInspector`, `Preprocessor`, and the endpoint mapper) are duplicated across `hits-preprocess.py` (CLI) and `data.py` (Python API). Logic changes must be applied to **both**.
+
 ## Features
 - **SMILES Standardization**:
   - Removes salts, isotopes, and stereochemistry (optional).
@@ -21,7 +34,7 @@ This repository will be updated when the K-MELLODDY standard data format is chan
 - **pH Correction**:
   - **NEW**: Corrects pH-dependent activity values to a target pH (default: 7.4, physiological pH).
   - Supports three correction methods: Henderson-Hasselbalch equation, empirical correction, and molecular properties-based correction.
-  - Automatically detects pH-related data when 'pH' is found in Test_Type column.
+  - Infers pH from `Test_Subject` (`pH7.4`), `Measurement_Condition` (bare number), and `Test_Type`, in addition to dedicated pH columns.
   - Creates new columns with pH-corrected values for each method.
   - Handles missing pH data gracefully.
 - **Input File Support**:
@@ -81,9 +94,10 @@ This pipeline can convert K-MELLODDY standard data into a GIST format matrix whe
 - **Integrated Endpoint Mapping**: Rule-based endpoint matching with 100+ predefined synonyms (fully offline, no API required)
 - **Three-Tier Matching Strategy**:
   1. **Exact Match**: Direct lookup in synonym dictionary
-  2. **Substring Match**: Prioritizes longer, more specific matches
-  3. **Similarity Match**: Token overlap and sequence similarity (with special handling for CYP endpoints)
-- **CYP Endpoint Protection**: Prevents false positives (e.g., CYP2C9 ↔ CYP2D6) by requiring exact CYP number matches
+  2. **Whole-Token Match**: Contiguous token-sequence matching (prefers the longest, latest match) so short keys like `tr`/`gr` do not substring-match inside `transporter`
+  3. **Similarity Match**: Token overlap and sequence similarity (fallback)
+- **CYP Endpoint Protection**: A regex-based CYP guard (in **both** mappers) maps only the exact isoform; `CYP1A1`/`CYP2C8` (no GIST slot) stay unmapped and `CYP3A4_MDZ`/`CYP3A4_TST` merge into `CYP3A4_Inhibitor`
+- **Unmappable Endpoints**: Endpoints with no GIST column (`Cytotoxicity`, `Genetoxicity`) are never force-mapped via similarity; they are reported to `*_unmapped.csv`
 - **SI Unit Conversion**: Automatically converts units to SI using the built-in `UnitConverter`
 - **Missing Data Handling**: Uses `NaN` by default to distinguish between actual zero measurements and missing data (configurable via `fill_missing` parameter)
 - **PK Data Support**: For PK (patient-origin) data, duplicate rows per SMILES are preserved with aggregated measurements
@@ -98,7 +112,7 @@ This pipeline can convert K-MELLODDY standard data into a GIST format matrix whe
   - Automatically falls back to `manual` mode if credentials or dependencies are missing
 
 ### GIST Endpoint List
-The list of GIST endpoints is hardcoded in `data.py` (no external file dependency). Includes 70+ standardized endpoints covering:
+The list of GIST endpoints is defined in `gist/gist_format.txt` (and mirrored in `data.py`). It contains 86 standardized endpoint columns covering:
 - Permeability (Caco2, PAMPA, HIA, BBB, etc.)
 - Transporters (P-gp, BCRP, OATP, MATE, OCT2)
 - CYPs (CYP1A2, CYP2B6, CYP2C9, CYP2C19, CYP2D6, CYP3A4 as Inhibitor/Substrate)
@@ -153,6 +167,8 @@ gist_matrix.to_csv('output_gist_matrix.csv', index=False)
 ### Generated Files
 - `*_gist_matrix.csv`: GIST format matrix (SMILES × GIST endpoints)
 - `*_PK_gist_matrix.csv`: If PK rows detected (includes aggregated measurements)
+- `*_unmapped.csv`: **NEW** — rows whose endpoint has no GIST column (reported instead of silently dropped)
+- `*_HumanPK.csv`: **NEW** — Human PK workbooks (wide-format, non-GIST schema) written out separately
 - Corresponding `*_gist_matrix_metadata.json`: Processing metadata (if using CLI)
 
 ## Installation
@@ -257,15 +273,18 @@ Optional but recommended columns:
 - **Test_Dose**: Specifies dosage information (automatically included for Pharmacokinetics tests).
 - **Chemical_ID**: Compound identifier (will be included in molecule visualizations if present).
 - **Measurement_Unit**: Unit of measurement (e.g., μg/mL, μM, hours) for unit conversion to SI units. Creates `measurement_value_si` and `measurement_unit_si` columns.
-- **pH-related columns**: pH value column (e.g., pH, pH_Value, Measurement_pH) for pH correction when Test_Type contains 'pH'. **NEW**: pH can be automatically inferred from Test_Type if pH column is missing.
+- **pH-related columns**: pH value column (e.g., pH, pH_Value, Measurement_pH) for pH correction. **NEW (v4.6)**: pH is also inferred from `Test_Subject` (`pH7.4`), `Measurement_Condition` (bare number), or `Test_Type` when no dedicated pH column exists.
 - **Test**: Test identifier (e.g., 'Pharmacokinetics', 'ADMET').
 - **Test_Type**: Type of test (e.g., 'pH4.0', 'pH 7.4').
 - **Measurement_Type**: Type of measurement.
 
-**NEW**: Additional columns in new K-MELLODDY format:
-- **Measurement_Conc**: Concentration information for measurements.
+**NEW**: Additional columns in the v4.6 K-MELLODDY format:
+- **Measurement_Conc**: Concentration information for measurements (implicit `uM`).
 - **Measurement_Temp**: Temperature information for measurements.
-- **Measurement_Class**: Classification information for measurements.
+- **Measurement_Class**: Classification information (multi-meaning; used as a group key so different meanings are not merged).
+- **Measurement_Condition**: Assay condition (e.g. pH for Permeability/BBB/PPB).
+- **Measurement_Route / Measurement_Sex / Measurement_Formulation**: VIVO PK metadata (included in task grouping).
+- **Measurement_Value(AtoB) / Measurement_Value(BtoA)**: Permeability directional values (bracket lists).
 
 ### Special Cases Handling
 The pipeline includes special handling for certain data types:

--- a/config/preprocess_defaults.yaml
+++ b/config/preprocess_defaults.yaml
@@ -1,6 +1,6 @@
 # Default configuration for the hits-preprocess pipeline.
 # Update `input_path` to point to your K-MELLODDY standard dataset before running.
-input_path: ./forum_sample/71900_250327_Solubility_Solubility_pH4.0_Not_specified_Not_specified_processed.csv
+input_path: ./input_data/data_sample.csv
 
 # General output options
 output_path: ./processed_data
@@ -29,9 +29,9 @@ split: null      # one of [random, scaffold, stratified]; null skips splitting
 test_size: 0.2
 valid_size: 0.1
 
-# Column names
-activity_col: Measurement_Value_scaled
-smiles_col: Standardized_SMILES
+# Column names (raw-input defaults; the pipeline derives *_scaled / Standardized_SMILES).
+activity_col: Measurement_Value
+smiles_col: SMILES_Structure_Parent
 
 # Logging
 debug: false

--- a/data.py
+++ b/data.py
@@ -15,6 +15,9 @@ from rdkit.Chem.MolStandardize.rdMolStandardize import StandardizeSmiles
 from rdkit.Chem.rdMolDescriptors import GetMorganFingerprintAsBitVect
 from rdkit.Chem import AllChem, Descriptors, MACCSkeys, ChemicalFeatures, Fragments
 
+import logging
+logger = logging.getLogger(__name__)
+
 ##### Featurizer #####
 allowable_features = {
 	'possible_atomic_num_list': list(range(1, 119)),
@@ -852,7 +855,7 @@ def recognize_task_type(each_df, activity_col='measurement_value'):
 		return "classification"
 	
 	try:
-		numeric_values = pd.to_numeric(each_df[activity_col].astype(str).str.replace(r'^[<>]\s*', '', regex=True), errors='coerce')
+		numeric_values = pd.to_numeric(each_df[activity_col].astype(str).str.replace(r'^[<>]=?\s*', '', regex=True), errors='coerce')
 		if numeric_values.isna().sum() > 0:
 			return "classification"
 		unique_values = numeric_values.dropna().unique()
@@ -902,18 +905,50 @@ class UnitConverter:
 			'm': 'm', 'cm': 'cm', 'mm': 'mm', 'um': 'um', 'nm': 'nm', 'pm': 'pm',
 			'angstrom': 'angstrom', 'a': 'angstrom',
 		}
-	
+		self.compound_unit_mappings = {
+			'ng*h/ml': 'ng*hour/mL', 'ng*hr/ml': 'ng*hour/mL', 'ng*hour/ml': 'ng*hour/mL',
+			'ug*h/ml': 'ug*hour/mL', 'mg*h/ml': 'mg*hour/mL',
+			'l/hr/kg': 'L/hour/kg', 'l/h/kg': 'L/hour/kg', 'ml/min/kg': 'mL/minute/kg',
+			'ul/min/mg': 'uL/minute/mg', 'ml/min/mg': 'mL/minute/mg',
+			'min-1': '1/minute', 'hr-1': '1/hour', 'h-1': '1/hour', 's-1': '1/second',
+		}
+		self.keep_as_is_units = {'1e-6 cm/s', 'ratio', 'fold', 'percent', 'dimensionless', 'x'}
+
 	def normalize_unit_string(self, unit_str):
-		"""Normalize unit string to standard format"""
-		if not unit_str or pd.isna(unit_str) or unit_str == "Not specified":
+		"""Normalize a unit string to a pint-parseable (or keep-as-is) form,
+		preserving '.', '-', '*', '^', '/', '·' so composite/exponent units
+		survive (e.g. '10-6 cm/s', 'ng·h/mL', 'min-1')."""
+		if unit_str is None or (isinstance(unit_str, float) and pd.isna(unit_str)):
 			return None
-		unit_str = str(unit_str).strip().lower()
-		unit_str = re.sub(r'\s+', '', unit_str)
-		unit_str = re.sub(r'[^\w/%]', '', unit_str)
-		if unit_str in self.unit_mappings:
-			return self.unit_mappings[unit_str]
-		return unit_str
-	
+		u = str(unit_str).strip()
+		if u in ('', '-', 'Not specified', 'nan', 'NaN', 'None'):
+			return None
+		# Molar concentrations are case-sensitive (uM/nM/mM/pM/M != length).
+		molar = re.fullmatch(r'([munp]?)M', u.replace(' ', ''))
+		if molar:
+			return {'u': 'uM', 'm': 'mM', 'n': 'nM', 'p': 'pM', '': 'M'}[molar.group(1)]
+		low = u.lower()
+		low = low.replace('·', '*').replace('×', '*').replace('•', '*')
+		low = re.sub(r'\s+', '', low)
+		if re.fullmatch(r'(x)?10\^?-6cm/s(ec)?', low):
+			return '1e-6 cm/s'
+		if low in ('ratio', 'fold', 'x'):
+			return low
+		if low in ('%', 'percent'):
+			return 'percent'
+		m = re.fullmatch(r'([a-z]+)-1', low)
+		if m and m.group(1) in ('min', 'hr', 'h', 's', 'sec'):
+			base = {'min': 'minute', 'hr': 'hour', 'h': 'hour', 's': 'second', 'sec': 'second'}[m.group(1)]
+			return f'1/{base}'
+		if 'cell' in low:
+			return low
+		low = low.replace('^', '**')
+		if low in self.compound_unit_mappings:
+			return self.compound_unit_mappings[low]
+		if low in self.unit_mappings:
+			return self.unit_mappings[low]
+		return low
+
 	def convert_to_si(self, value, unit_str):
 		"""Convert a value with unit to SI units"""
 		if not PINT_AVAILABLE:
@@ -922,13 +957,15 @@ class UnitConverter:
 			normalized_unit = self.normalize_unit_string(unit_str)
 			if not normalized_unit:
 				return value, unit_str, unit_str
+			if normalized_unit in self.keep_as_is_units or 'cell' in normalized_unit:
+				return value, normalized_unit, unit_str
 			try:
 				quantity = value * self.ureg(normalized_unit)
-			except:
-				try:
-					quantity = value * self.ureg(unit_str)
-				except:
-					return value, unit_str, unit_str
+			except Exception:
+				logger.warning(
+					f"Could not parse unit '{unit_str}' (normalized '{normalized_unit}'). "
+					f"Keeping original value unconverted.")
+				return value, unit_str, unit_str
 			si_quantity = quantity.to_base_units()
 			si_unit_str = str(si_quantity.units)
 			return float(si_quantity.magnitude), si_unit_str, unit_str
@@ -943,8 +980,9 @@ class UnitConverter:
 			new_value_col = f"{value_col}_si"
 		if new_unit_col is None:
 			new_unit_col = f"{unit_col}_si"
-		df[new_value_col] = df[value_col].copy()
-		df[new_unit_col] = df[unit_col].copy()
+		# object dtype so per-row float/str assignment works under pandas 3.0.
+		df[new_value_col] = df[value_col].astype(object)
+		df[new_unit_col] = df[unit_col].astype(object)
 		for idx, row in df.iterrows():
 			try:
 				value = row[value_col]
@@ -953,7 +991,7 @@ class UnitConverter:
 					continue
 				try:
 					if isinstance(value, str):
-						value = re.sub(r'^[<>]\s*', '', value)
+						value = re.sub(r'^[<>]=?\s*', '', value)
 						value = float(value)
 				except:
 					continue
@@ -1111,8 +1149,9 @@ class pHCorrector:
 		else:
 			method_suffix = {'henderson_hasselbalch': 'hh', 'empirical': 'emp', 'molecular_properties': 'mp'}
 			new_cols = [f"{activity_col}_pH_corrected_{method_suffix[self.method]}"]
+		# object dtype so per-row float assignment works under pandas 3.0.
 		for col in new_cols:
-			df[col] = df[activity_col].copy()
+			df[col] = df[activity_col].astype(object)
 		for idx, row in df.iterrows():
 			try:
 				activity = row[activity_col]
@@ -1164,15 +1203,92 @@ def process_smiles_batch_global(smiles_batch):
 	return results
 
 
+def _parse_bracket_numbers(cell):
+	"""Parse a Permeability cell into a list of floats/None.
+
+	Accepts bracketed lists like '[6,2]', '[6,]', '[,2]', plain scalars '6.2',
+	or empty/placeholder values. An empty slot becomes None.
+	"""
+	if cell is None:
+		return []
+	s = str(cell).strip()
+	if s in ("", "-", "nan", "NaN", "None", "Not specified"):
+		return []
+	s = s.strip("[]")
+	if s == "":
+		return []
+	out = []
+	for part in s.split(","):
+		part = part.strip()
+		if part == "":
+			out.append(None)
+			continue
+		part = re.sub(r'^[<>]=?\s*', '', part)
+		try:
+			out.append(float(part))
+		except ValueError:
+			out.append(None)
+	return out
+
+
+def parse_permeability_pair(atob_cell, btoa_cell):
+	"""Return (AtoB, BtoA) floats from the two Permeability value columns.
+
+	Handles the v4.6 '[Value, Value]=[AB, BA]' convention whether the pair is
+	split across the AtoB/BtoA columns or carried as a full list in either one.
+	"""
+	ab = _parse_bracket_numbers(atob_cell)
+	ba = _parse_bracket_numbers(btoa_cell)
+	atob = ab[0] if len(ab) >= 1 else None
+	btoa = ba[1] if len(ba) >= 2 else (ba[0] if len(ba) == 1 else None)
+	if atob is None and len(ba) >= 1:
+		atob = ba[0]
+	if btoa is None and len(ab) >= 2:
+		btoa = ab[1]
+	return atob, btoa
+
+
+def _expand_permeability_columns(df):
+	"""Split Permeability's ``measurement_value(atob)``/``(btoa)`` list columns
+	into a scalar ``measurement_value`` (AtoB) plus ``measurement_efflux_ratio``
+	(BtoA/AtoB). Operates on lowercase-normalized column names.
+	"""
+	ab_col, ba_col = 'measurement_value(atob)', 'measurement_value(btoa)'
+	if ab_col not in df.columns and ba_col not in df.columns:
+		return df
+	atob_vals, btoa_vals, ratio_vals = [], [], []
+	for _, row in df.iterrows():
+		atob, btoa = parse_permeability_pair(row.get(ab_col), row.get(ba_col))
+		atob_vals.append(atob)
+		btoa_vals.append(btoa)
+		if atob not in (None, 0) and btoa is not None:
+			ratio_vals.append(btoa / atob)
+		else:
+			ratio_vals.append(None)
+	if 'measurement_value' not in df.columns:
+		df['measurement_value'] = atob_vals
+	else:
+		existing = df['measurement_value']
+		df['measurement_value'] = [
+			a if (pd.isna(e) or str(e) in ("", "Not specified")) else e
+			for e, a in zip(existing, atob_vals)
+		]
+	df['measurement_value_btoa'] = btoa_vals
+	df['measurement_efflux_ratio'] = ratio_vals
+	return df
+
+
 class DataInspector:
 	"""Data inspector for loading and validating data (supports CSV path or DataFrame)"""
 	def __init__(self, input_path=None, df=None, smiles_column='smiles_structure_parent',
 				activity_column='measurement_value',
-				condition_columns=['test', 'test_type', 'test_subject', 'measurment_type',
-								'measurement_conc', 'measurement_temp', 'measurement_class']):
+				condition_columns=['test', 'test_type', 'test_subject', 'measurement_type',
+								'measurement_conc', 'measurement_temp', 'measurement_class',
+								'measurement_route', 'measurement_sex', 'measurement_formulation']):
 		self.smiles_col = smiles_column
 		self.activity_col = activity_column
 		self.condition_columns = condition_columns
+		self.is_human_pk = False
 		if df is not None:
 			self.df = self._process_dataframe(df)
 		elif input_path is not None:
@@ -1181,19 +1297,16 @@ class DataInspector:
 			raise ValueError("Either input_path or df must be provided")
 	
 	def normalize_column_names(self, df):
-		"""Normalize column names to handle both old and new K-MELLODDY formats"""
-		column_mapping = {
-			'test_subject*': 'test_subject',
-			'Unnamed: 10': 'measurement_value',  # Only map if measurement_value doesn't exist
-			'measurement_conc': 'measurement_conc',
-			'measurement_temp': 'measurement_temp',
-			'measurement_class': 'measurement_class',
-		}
-		# Only apply Unnamed: 10 -> measurement_value mapping if measurement_value doesn't exist
+		"""Normalize column names to canonical lowercase K-MELLODDY names.
+
+		The real value column is preserved; the legacy 'Unnamed: 10' remap is
+		applied only as a fallback when no measurement_value survived (old
+		merged-cell layout).
+		"""
+		df = self._normalize_column_names_before_concat(df)
+		# Legacy fallback for the old merged-cell layout.
 		if 'measurement_value' not in df.columns and 'Unnamed: 10' in df.columns:
 			df = df.rename(columns={'Unnamed: 10': 'measurement_value'})
-		# Apply other mappings
-		df = df.rename(columns={k: v for k, v in column_mapping.items() if k != 'Unnamed: 10'})
 		df = df.loc[:, ~df.columns.str.contains('^Unnamed')]
 		return df
 	
@@ -1212,36 +1325,58 @@ class DataInspector:
 				df[col] = df[col].astype(str).str.replace('μ', 'u')
 				df[col] = df[col].apply(lambda x: self._replace_special_chars(x) if isinstance(x, str) else x)
 		df = self.normalize_column_names(df)
+		df = _expand_permeability_columns(df)
 		for col in self.condition_columns:
 			if col not in df.columns:
 				df[col] = "Not specified"
 		return df
 	
+	# Canonical (lowercase) column names keyed by their normalized form
+	# (lowercased, trailing '*' and whitespace stripped). Covers v4.6 spelling,
+	# the legacy 'Measurment_*' typo, 'Test_Species' -> 'test_subject', and VIVO's
+	# lowercase 'Measurement_value'. Mirrors hits-preprocess.py CANONICAL_COLUMNS.
+	CANONICAL_COLUMNS = {
+		'chemical id': 'chemical id',
+		'chemical name': 'chemical name',
+		'smiles_structure_parent': 'smiles_structure_parent',
+		'smiles_salt': 'smiles_salt',
+		'test': 'test',
+		'test_type': 'test_type',
+		'test_subject': 'test_subject',
+		'test_species': 'test_subject',          # legacy rename
+		'test_dose': 'test_dose',
+		'measurement_type': 'measurement_type',
+		'measurment_type': 'measurement_type',   # legacy typo
+		'measurement_relation': 'measurement_relation',
+		'measurment_relation': 'measurement_relation',
+		'measurement_value': 'measurement_value',
+		'measurment_value': 'measurement_value',
+		'measurement_value(atob)': 'measurement_value(atob)',
+		'measurement_value(btoa)': 'measurement_value(btoa)',
+		'measurement_unit': 'measurement_unit',
+		'measurment_unit': 'measurement_unit',
+		'measurement_conc': 'measurement_conc',
+		'measurement_temp': 'measurement_temp',
+		'measurement_condition': 'measurement_condition',
+		'measurment_condition': 'measurement_condition',
+		'measurement_class': 'measurement_class',
+		'measurement_route': 'measurement_route',
+		'measurement_sex': 'measurement_sex',
+		'measurement_formulation': 'measurement_formulation',
+		'comment': 'comment',
+	}
+
 	def _normalize_column_names_before_concat(self, df):
-		"""Normalize column names before concatenating multiple sheets"""
-		# Standardize all column names to lowercase
+		"""Normalize column names to canonical lowercase names before concat."""
 		column_mapping = {}
 		for col in df.columns:
-			col_lower = col.lower()
-			# Map common column name variations to lowercase
-			if col_lower == 'measurement_value' and col != 'measurement_value':
-				column_mapping[col] = 'measurement_value'
-			elif col_lower == 'measurement_unit' and col != 'measurement_unit':
-				column_mapping[col] = 'measurement_unit'
-			elif col_lower == 'measurement_type' and col != 'measurement_type':
-				column_mapping[col] = 'measurement_type'
-			elif col_lower == 'measurment_type' and col != 'measurement_type':
-				column_mapping[col] = 'measurement_type'
-			elif col_lower == 'smiles_structure_parent' and col != 'smiles_structure_parent':
-				column_mapping[col] = 'smiles_structure_parent'
-			elif col_lower == 'test' and col != 'test':
-				column_mapping[col] = 'test'
-			elif col_lower == 'test_type' and col != 'test_type':
-				column_mapping[col] = 'test_type'
-			elif col_lower == 'test_subject' and col != 'test_subject':
-				column_mapping[col] = 'test_subject'
+			key = str(col).strip().rstrip('*').strip().lower()
+			canonical = self.CANONICAL_COLUMNS.get(key)
+			if canonical and canonical != col:
+				column_mapping[col] = canonical
 		if column_mapping:
 			df = df.rename(columns=column_mapping)
+		df = df.loc[:, ~df.columns.duplicated()]
 		return df
 	
 	def _replace_special_chars(self, text):
@@ -1281,6 +1416,21 @@ class DataInspector:
 			# Use context manager to ensure Excel file is properly closed
 			with pd.ExcelFile(input_path) as excel_file:
 				sheets = excel_file.sheet_names
+				# Human PK: wide-format, 3-row header, non-GIST schema.
+				human_pk_sheets = [s for s in sheets
+								if str(s).startswith('데이터') and 'human pk' in str(s).lower()]
+				if human_pk_sheets:
+					self.is_human_pk = True
+					hpk_dfs = [pd.read_excel(excel_file, sheet_name=s, header=2).fillna("Not specified")
+							for s in human_pk_sheets]
+					df = pd.concat(hpk_dfs, ignore_index=True)
+					df = df.loc[:, ~df.columns.duplicated()]
+					if self.smiles_col not in df.columns:
+						for col in df.columns:
+							if 'smiles' in str(col).lower():
+								df = df.rename(columns={col: self.smiles_col})
+								break
+					return df
 				dfs = []
 				if 'ADMET' in sheets:
 					admet_df = pd.read_excel(excel_file, sheet_name='ADMET').fillna("Not specified")
@@ -1326,6 +1476,7 @@ class DataInspector:
 				df[col] = df[col].astype(str).str.replace('μ', 'u')
 				df[col] = df[col].apply(lambda x: self._replace_special_chars(x) if isinstance(x, str) else x)
 		df = self.normalize_column_names(df)
+		df = _expand_permeability_columns(df)
 		for col in self.condition_columns:
 			if col not in df.columns:
 				df[col] = "Not specified"
@@ -1340,10 +1491,16 @@ class DataInspector:
 			return active_count >= 25 and inactive_count >= 25
 		else:
 			total_count = len(each_df)
-			if 'Measurement_Relation' in each_df.columns:
-				uncensored_count = len(each_df[~each_df['Measurement_Relation'].isin(['>', '<'])])
+			rel_col = 'measurement_relation' if 'measurement_relation' in each_df.columns else (
+				'Measurement_Relation' if 'Measurement_Relation' in each_df.columns else None)
+			if rel_col is not None:
+				# Censored = {>, >=, <, <=}; equality is stored as quoted '"="'.
+				rel_norm = (each_df[rel_col].astype(str)
+							.str.strip().str.strip('"').str.strip("'").str.strip())
+				censored_mask = rel_norm.isin(['>', '>=', '<', '<='])
+				uncensored_count = int((~censored_mask).sum())
 			else:
-				has_relation_mask = each_df[self.activity_col].astype(str).str.contains('^[<>]')
+				has_relation_mask = each_df[self.activity_col].astype(str).str.contains(r'^[<>]=?')
 				uncensored_count = len(each_df[~has_relation_mask])
 			return total_count >= 50 and uncensored_count >= 25
 
@@ -1549,7 +1706,15 @@ class Preprocessor:
 					self.create_classification_label(labels)
 			if self.detect_outliers:
 				self.detect_outlier_from_distribution()
-			if np.issubdtype(labels.dtype, np.number) or labels.str.match(r'^[<>]?\s*\d+\.?\d*$').any():
+			# pandas 3.0: np.issubdtype(StringDtype, np.number) raises; use pandas API.
+			is_numeric = pd.api.types.is_numeric_dtype(labels)
+			has_numeric_strings = False
+			if not is_numeric:
+				try:
+					has_numeric_strings = labels.astype(str).str.match(r'^[<>]?=?\s*\d+\.?\d*$').any()
+				except Exception:
+					has_numeric_strings = False
+			if is_numeric or has_numeric_strings:
 				self.scale_experiment_values(labels)
 			if self.label_type == 'Continuous' and self.task_type == "classification" and self.threshold is not None:
 				self.create_classification_label(labels)
@@ -1557,14 +1722,53 @@ class Preprocessor:
 			if self.activity_col not in self.final_cols:
 				self.final_cols.append(self.activity_col)
 	
+	def _infer_ph_column(self):
+		"""Infer a per-row pH value from v4.6 locations in priority order:
+		dedicated pH columns, test_subject ('pH7.4'), measurement_condition (bare
+		number or 'pH x'), then test_type. Returns a float Series (NaN if none)."""
+		ph_pattern = re.compile(r"pH\s*([0-9]+(?:\.[0-9]+)?)", flags=re.IGNORECASE)
+
+		def _ph_from_text(text):
+			m = ph_pattern.search(str(text))
+			if m:
+				try:
+					return float(m.group(1))
+				except ValueError:
+					return None
+			return None
+
+		def _bare_ph(text):
+			m = re.fullmatch(r"\s*([0-9]+(?:\.[0-9]+)?)\s*", str(text))
+			if m:
+				try:
+					v = float(m.group(1))
+					if 0.0 <= v <= 14.0:
+						return v
+				except ValueError:
+					return None
+			return None
+
+		inferred = pd.Series(np.nan, index=self.df.index, dtype=float)
+		for col in ['pH', 'pH_Value', 'Measurement_pH', 'Test_pH', 'ph']:
+			if col in self.df.columns:
+				inferred = inferred.combine_first(pd.to_numeric(self.df[col], errors='coerce'))
+		if 'test_subject' in self.df.columns:
+			inferred = inferred.combine_first(
+				pd.to_numeric(self.df['test_subject'].apply(_ph_from_text), errors='coerce'))
+		if 'measurement_condition' in self.df.columns:
+			mc = self.df['measurement_condition'].apply(
+				lambda x: _ph_from_text(x) if _ph_from_text(x) is not None else _bare_ph(x))
+			inferred = inferred.combine_first(pd.to_numeric(mc, errors='coerce'))
+		if 'test_type' in self.df.columns:
+			inferred = inferred.combine_first(
+				pd.to_numeric(self.df['test_type'].apply(_ph_from_text), errors='coerce'))
+		return inferred
+
 	def preprocess(self):
 		"""Main preprocessing pipeline"""
 		compounds = self.df[self.smiles_col]
 		labels = self.df[self.activity_col]
-		
-		# Backup original df before any modifications for potential recovery
-		original_df_backup = self.df.copy()
-		
+
 		if self.convert_units and 'measurement_unit' in self.df.columns:
 			try:
 				self.df = self.unit_converter.convert_column_to_si(
@@ -1577,44 +1781,13 @@ class Preprocessor:
 			except Exception:
 				pass
 		
-		if self.correct_pH and 'test_type' in self.df.columns:
-			pH_data_mask = self.df['test_type'].astype(str).str.contains('pH', case=False, na=False)
+		if self.correct_pH:
+			inferred_pH = self._infer_ph_column()
+			pH_data_mask = inferred_pH.notna()
 			if pH_data_mask.any():
 				try:
-					pH_col = None
-					possible_pH_cols = ['pH', 'pH_Value', 'Measurement_pH', 'Test_pH']
-					for col in possible_pH_cols:
-						if col in self.df.columns:
-							pH_col = col
-							break
-					if pH_col is None:
-						inferred_col = 'inferred_pH'
-						try:
-							self.df[inferred_col] = np.nan
-							pattern = re.compile(r"pH\s*([0-9]+(?:\.[0-9]+)?)", flags=re.IGNORECASE)
-							def _extract_ph(text):
-								s = str(text)
-								m = pattern.search(s)
-								if m:
-									try:
-										return float(m.group(1))
-									except Exception:
-										return None
-								tokens = re.split(r"[^A-Za-z0-9\.]+", s)
-								for tok in tokens:
-									if tok.lower().startswith('ph'):
-										num = tok[2:]
-										if num:
-											try:
-												return float(num)
-											except Exception:
-												continue
-								return None
-							self.df.loc[pH_data_mask, inferred_col] = self.df.loc[pH_data_mask, 'test_type'].apply(_extract_ph)
-							if self.df.loc[pH_data_mask, inferred_col].notna().any():
-								pH_col = inferred_col
-						except Exception:
-							pass
+					self.df['inferred_pH'] = inferred_pH
+					pH_col = 'inferred_pH'
 					if pH_col is not None:
 						pH_df = self.df[pH_data_mask].copy()
 						corrected_pH_df = self.pH_corrector.correct_column(
@@ -1649,34 +1822,16 @@ class Preprocessor:
 		
 		if not self.keep_duplicates and not is_pk_data:
 			before_count = len(self.df)
+			# Snapshot with all enriched columns (SI, pH_corrected, standardized)
+			# so recovery does not lose them if the strict dedup empties the set.
+			df_before_dedup = self.df.copy()
 			self.df.drop_duplicates(subset=["Standardized_SMILES"], keep=False, inplace=True, ignore_index=True)
 			after_count = len(self.df)
 			if after_count == 0 and before_count > 0:
-				# Rebuild df from original backup to preserve all columns including SI unit columns
-				# Reset to original state before preprocessing
-				self.df = original_df_backup.copy().reset_index(drop=True)
-				compounds = self.df[self.smiles_col]
-				labels = self.df[self.activity_col]
-				
-				# Re-run SI unit conversion if needed
-				if self.convert_units and 'measurement_unit' in self.df.columns:
-					try:
-						self.df = self.unit_converter.convert_column_to_si(
-							self.df, self.activity_col, 'measurement_unit',
-							f"{self.activity_col}_si", 'measurement_unit_si')
-						if f"{self.activity_col}_si" in self.df.columns:
-							if f"{self.activity_col}_si" not in self.final_cols:
-								self.final_cols.append(f"{self.activity_col}_si")
-						if 'measurement_unit_si' in self.df.columns:
-							if 'measurement_unit_si' not in self.final_cols:
-								self.final_cols.append('measurement_unit_si')
-					except Exception:
-						pass
-				
-				# Re-run compound and label preprocessing
-				self.preprocess_compounds(compounds)
-				self.preprocess_labels(labels)
-				self.df.drop_duplicates(subset=["Standardized_SMILES"], keep='first', inplace=True, ignore_index=True)
+				# Recover from the fully-processed frame, keeping the first row per
+				# SMILES so all columns (SI/pH/standardized) survive.
+				self.df = df_before_dedup.drop_duplicates(
+					subset=["Standardized_SMILES"], keep='first', ignore_index=True)
 			else:
 				self.df.drop_duplicates(subset=["Standardized_SMILES"], keep='first', inplace=True, ignore_index=True)
 		
@@ -1736,7 +1891,9 @@ DEFAULT_ENDPOINT_SYNONYMS = {
 	"vdss": "VDss", "volume of distribution": "VDss", "vd": "VDss",
 	# Transporters and pumps
 	"pgp inhibitor": "pgp_inhibitor", "pgp substrate": "pgp_substrate", "p-gp substrate": "pgp_substrate",
-	"p-gp inhibitor": "pgp_inhibitor", "bcrp inhibitor": "BCRP", "bcrp": "BCRP", "breast cancer resistance protein": "BCRP",
+	"p-gp inhibitor": "pgp_inhibitor", "p-gp": "pgp_inhibitor", "p_gp": "pgp_inhibitor",
+	"bcrp inhibitor": "BCRP", "bcrp": "BCRP", "breast cancer resistance protein": "BCRP",
+	"efflux ratio": "Efflux_ratio", "efflux_ratio": "Efflux_ratio",
 	"oatp1b1": "OATP1B1_Inhibitor", "oatp1b3": "OATP1B3_Inhibitor", "oatp2b1": "OATP2B1_Inhibitor",
 	"mate1": "MATE1_Inhibitor", "oct2": "OCT2_Inhibitor",
 	# CYPs - only map CYPs that exist in GIST format
@@ -1827,9 +1984,15 @@ class ManualConversionConfig:
 
 class ManualFormatConverter:
 	"""Endpoint converter using deterministic heuristics (integrated from manual_converter.py)"""
+	# CYP isoforms that actually have a GIST column; CYP1A1/CYP2C8 have none.
+	CYP_GIST_ISOFORMS = frozenset({"cyp1a2", "cyp2b6", "cyp2c9", "cyp2c19", "cyp2d6", "cyp3a4"})
+	# Endpoints present in v4.6 but with NO GIST column: never force-map them.
+	UNMAPPABLE_TOKENS = frozenset({"cytotoxicity", "genetoxicity"})
+
 	def __init__(self, config=None):
 		self.config = config or ManualConversionConfig()
 		self.gist_endpoints = self._load_gist_endpoints()
+		self._gist_set = set(self.gist_endpoints)
 		self._normalized_gist = {endpoint: self._normalize(endpoint) for endpoint in self.gist_endpoints}
 		self._gist_tokens = {endpoint: self._tokenize(norm) for endpoint, norm in self._normalized_gist.items()}
 		self.synonym_map = self._load_synonym_map()
@@ -1954,56 +2117,68 @@ class ManualFormatConverter:
 			return best_endpoint
 		return None
 	
+	@staticmethod
+	def _contiguous_index(key_tokens, tokens):
+		"""Start index of key_tokens as a contiguous sublist of tokens, else -1.
+		Whole-token matching so short keys ('tr'/'gr') don't substring-match
+		inside 'transporter'."""
+		n, m = len(tokens), len(key_tokens)
+		if m == 0 or m > n:
+			return -1
+		for i in range(n - m + 1):
+			if tokens[i:i + m] == key_tokens:
+				return i
+		return -1
+
+	def _cyp_guard(self, normalized):
+		"""Map CYP endpoints to their exact GIST isoform column, never a neighbour.
+		Returns a GIST column, '' (CYP with no GIST slot -> unmapped), or None."""
+		isoforms = re.findall(r"cyp\d+[a-z]\d*", normalized)
+		if not isoforms:
+			return None
+		iso = isoforms[0]
+		role = "Substrate" if "substrate" in normalized else "Inhibitor"
+		if iso in self.CYP_GIST_ISOFORMS:
+			target = f"{iso.upper()}_{role}"
+			if target in self._gist_set:
+				return target
+		return ""
+
 	def match_endpoint(self, endpoint):
 		"""Match single endpoint"""
 		normalized = self._normalize(endpoint)
 		if not normalized:
 			return str(endpoint)
 		tokens = self._tokenize(normalized)
-		
-		# Check for endpoints that should NOT be mapped (not in GIST format)
-		unmappable_patterns = ['cyp1a1', 'cyp2c8']
-		for pattern in unmappable_patterns:
-			if pattern in normalized:
-				# Return original endpoint if it contains unmappable pattern
-				return str(endpoint)
-		
+
+		# CYP guard first: exact isoform only, no cross-isoform similarity bleed.
+		cyp = self._cyp_guard(normalized)
+		if cyp is not None:
+			return cyp if cyp else str(endpoint)
+
 		# Priority 1: Exact match
 		if normalized in self.synonym_map:
 			return self.synonym_map[normalized]
-		
-		# Priority 2: Substring match with priority for longer/more specific matches
-		# Sort by length (longer first) to prioritize more specific matches
-		sorted_synonyms = sorted(self.synonym_map.items(), key=lambda x: len(x[0]), reverse=True)
-		for synonym_key, mapped in sorted_synonyms:
-			if self.config.prefer_exact and synonym_key == normalized:
-				return mapped
-			# Check if synonym is contained in normalized string
-			if synonym_key in normalized:
-				# Additional check: ensure we're not matching partial words incorrectly
-				# For example, "er" should not match "herg" or "liver"
-				synonym_tokens = self._tokenize(synonym_key)
-				# If synonym has multiple tokens, check if all are present
-				if len(synonym_tokens) > 1:
-					if all(token in tokens for token in synonym_tokens):
-						return mapped
-				# For single token synonyms, check if it's a standalone word or part of a compound
-				elif len(synonym_tokens) == 1:
-					synonym_token = synonym_tokens[0]
-					# Special handling for common keywords that should match
-					priority_keywords = ['herg', 'hlm', 'rlm', 'ames', 'cyp1a2', 'cyp2b6', 'cyp2c9', 
-										'cyp2c19', 'cyp2d6', 'cyp3a4', 'liver', 'microsome', 'hepatocyte']
-					if synonym_token in priority_keywords and synonym_token in normalized:
-						return mapped
-					# For other cases, check if it's a word boundary match
-					# This is a simple heuristic - in practice, word boundaries are complex
-					if synonym_token in normalized:
-						# Avoid matching "er" in "herg" or "liver"
-						if synonym_token == 'er' and ('herg' in normalized or 'liver' in normalized):
-							continue
-						return mapped
-		
-		# Priority 3: Similarity-based matching (but skip if contains unmappable patterns)
+
+		# Endpoints with no GIST slot: leave unmapped (do not force via similarity).
+		if any(tok in self.UNMAPPABLE_TOKENS for tok in tokens):
+			return str(endpoint)
+
+		# Priority 2: whole-token subsequence match; prefer longest key, then the
+		# latest start (Measurement_Type is the last, most-specific component).
+		best = None  # (num_tokens, start_index, mapped)
+		for synonym_key, mapped in self.synonym_map.items():
+			key_tokens = tuple(synonym_key.split())
+			idx = self._contiguous_index(key_tokens, tokens)
+			if idx < 0:
+				continue
+			cand = (len(key_tokens), idx, mapped)
+			if best is None or cand[:2] > best[:2]:
+				best = cand
+		if best is not None:
+			return best[2]
+
+		# Priority 3: Similarity-based matching
 		matched = self._match_with_similarity(normalized, tokens)
 		if matched:
 			return matched
@@ -2082,6 +2257,13 @@ def preprocess_to_gist(input_data, config=None, smiles_col='smiles_structure_par
 		inspector = DataInspector(input_path=str(input_path), smiles_column=smiles_col, activity_column=activity_col)
 		df = inspector.df.copy()
 		skip_preprocessing = False  # Force preprocessing for raw CSV files
+		# Human PK is a wide-format, non-GIST schema: return the raw table instead
+		# of forcing endpoint mapping (which yields an empty/garbage matrix).
+		if getattr(inspector, "is_human_pk", False):
+			import warnings as _warnings
+			_warnings.warn("Human PK detected: returning raw wide-format table; "
+						"not a GIST-mappable schema.")
+			return df
 	elif isinstance(input_data, pd.DataFrame):
 		if skip_preprocessing:
 			# Use DataFrame directly without DataInspector normalization
@@ -2231,13 +2413,43 @@ def preprocess_to_gist(input_data, config=None, smiles_col='smiles_structure_par
 	else:
 		value_col = activity_col
 	
+	# H6: qualitative Ames/Genetoxicity results store Positive/Negative in the
+	# unit column with a '-' value; encode as 1.0/0.0 before numeric coercion.
+	if unit_col is not None and unit_col in df.columns:
+		unit_lower = df[unit_col].astype(str).str.strip().str.lower()
+		qual_mask = unit_lower.isin(["positive", "negative"])
+		if qual_mask.any():
+			df.loc[qual_mask, value_col] = unit_lower[qual_mask].map(
+				{"positive": 1.0, "negative": 0.0})
+
 	df[value_col] = pd.to_numeric(df[value_col], errors='coerce')
+
+	# Permeability: derive dimensionless Efflux_ratio (BtoA/AtoB) rows.
+	if 'measurement_efflux_ratio' in df.columns:
+		ratio_num = pd.to_numeric(df['measurement_efflux_ratio'], errors='coerce')
+		er_mask = ratio_num.notna()
+		if er_mask.any():
+			er = df.loc[er_mask].copy()
+			er['gist_endpoint'] = 'Efflux_ratio'
+			er[value_col] = ratio_num.loc[er_mask].values
+			df = pd.concat([df, er], ignore_index=True)
 	
 	# Load GIST columns (use hardcoded list)
 	gist_cols = GIST_ENDPOINTS.copy()
 	if not gist_cols:
 		raise RuntimeError("GIST endpoint list is empty.")
-	
+
+	# M1/M2: report endpoints with no GIST target rather than dropping silently.
+	gist_set = set(gist_cols)
+	unmapped_mask = ~df["gist_endpoint"].isin(gist_set)
+	if unmapped_mask.any():
+		counts = df.loc[unmapped_mask, "endpoint_canonical"].value_counts()
+		logger.warning(
+			"%d row(s) across %d endpoint(s) have no GIST target and are excluded "
+			"from the matrix: %s",
+			int(unmapped_mask.sum()), len(counts),
+			", ".join(f"{ep!r}x{int(n)}" for ep, n in counts.head(20).items()))
+
 	# Detect PK rows
 	def is_pk_row(row):
 		txt = " ".join([str(row.get(col, "")) for col in ["test", "test_type", "measurement_type", "measurment_type", "test_subject"]]).lower()

--- a/hits-preprocess.py
+++ b/hits-preprocess.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass
 from omegaconf import OmegaConf, DictConfig, MISSING
 from omegaconf.errors import ConfigKeyError, ValidationError
 from rdkit import Chem
-from rdkit.Chem import SaltRemover, MolStandardize, Draw
+from rdkit.Chem import SaltRemover, MolStandardize, Draw, Descriptors
 from rdkit.Chem.Scaffolds import MurckoScaffold
 from sklearn.cluster import DBSCAN
 from sklearn.mixture import GaussianMixture
@@ -193,7 +193,7 @@ def recognize_task_type(each_df, activity_col='Measurement_Value'):
     # Check if all values can be converted to numbers
     try:
         # Try to convert to numeric, excluding comparison operators (>, <)
-        numeric_values = pd.to_numeric(each_df[activity_col].astype(str).str.replace(r'^[<>]\s*', '', regex=True), errors='coerce')
+        numeric_values = pd.to_numeric(each_df[activity_col].astype(str).str.replace(r'^[<>]=?\s*', '', regex=True), errors='coerce')
         if numeric_values.isna().sum() > 0:
             # If values that can't be converted to numbers exist, it's a classification task
             return "classification"
@@ -319,6 +319,23 @@ class UnitConverter:
             'a': 'angstrom',
         }
         
+        # v4.6 compound units (keyed by lowercased, whitespace-stripped form after
+        # '·'->'*' and '^'->'**') mapped to pint-parseable strings.
+        self.compound_unit_mappings = {
+            'ng*h/ml': 'ng*hour/mL', 'ng*hr/ml': 'ng*hour/mL', 'ng*hour/ml': 'ng*hour/mL',
+            'ug*h/ml': 'ug*hour/mL', 'mg*h/ml': 'mg*hour/mL',
+            'l/hr/kg': 'L/hour/kg', 'l/h/kg': 'L/hour/kg', 'ml/min/kg': 'mL/minute/kg',
+            'ul/min/mg': 'uL/minute/mg', 'ml/min/mg': 'mL/minute/mg',
+            'min-1': '1/minute', 'hr-1': '1/hour', 'h-1': '1/hour', 's-1': '1/second',
+        }
+
+        # Reporting/dimensionless units whose numeric value must NOT be rescaled
+        # (leaving them to pint would e.g. turn 10-6 cm/s into a ~1e8x corruption,
+        # or 50% into 0.5). Kept verbatim with an explicit label.
+        self.keep_as_is_units = {
+            '1e-6 cm/s', 'ratio', 'fold', 'percent', 'dimensionless', 'x',
+        }
+
         # SI unit targets for different measurement types
         self.si_targets = {
             'concentration': 'M',  # Molar (mol/L)
@@ -334,23 +351,58 @@ class UnitConverter:
     
     def normalize_unit_string(self, unit_str):
         """
-        Normalize unit string to standard format
+        Normalize a unit string to a pint-parseable (or keep-as-is) form.
+
+        Unlike the old implementation this PRESERVES '.', '-', '*', '^', '/' and
+        '·' so composite/exponent units survive (e.g. '10-6 cm/s', 'ng·h/mL',
+        'min-1'). Returns None for blank/placeholder units.
         """
-        if not unit_str or pd.isna(unit_str) or unit_str == "Not specified":
+        if unit_str is None or (isinstance(unit_str, float) and pd.isna(unit_str)):
             return None
-            
-        # Convert to string and clean up
-        unit_str = str(unit_str).strip().lower()
-        
-        # Remove extra spaces and special characters
-        unit_str = re.sub(r'\s+', '', unit_str)
-        unit_str = re.sub(r'[^\w/%]', '', unit_str)
-        
-        # Map to standard format
-        if unit_str in self.unit_mappings:
-            return self.unit_mappings[unit_str]
-        
-        return unit_str
+        u = str(unit_str).strip()
+        if u in ('', '-', 'Not specified', 'nan', 'NaN', 'None'):
+            return None
+
+        # Molar concentrations are CASE-SENSITIVE: uM/nM/mM/pM/M mean molar, not
+        # length (um=micrometre). Resolve them before lowercasing collapses the M.
+        molar = re.fullmatch(r'([munp]?)M', u.replace(' ', ''))
+        if molar:
+            return {'u': 'uM', 'm': 'mM', 'n': 'nM', 'p': 'pM', '': 'M'}[molar.group(1)]
+
+        low = u.lower()
+        low = low.replace('·', '*').replace('×', '*').replace('•', '*')
+        low = re.sub(r'\s+', '', low)
+
+        # Permeability reporting unit: '10-6 cm/s', '10^-6 cm/s', 'x10-6 cm/s', ...
+        if re.fullmatch(r'(x)?10\^?-6cm/s(ec)?', low):
+            return '1e-6 cm/s'
+
+        # Dimensionless / reporting units kept verbatim.
+        if low in ('ratio', 'fold', 'x'):
+            return low
+        if low in ('%', 'percent'):
+            return 'percent'
+
+        # First-order rate constants: 'min-1' -> '1/minute', etc.
+        m = re.fullmatch(r'([a-z]+)-1', low)
+        if m and m.group(1) in ('min', 'hr', 'h', 's', 'sec'):
+            base = {'min': 'minute', 'hr': 'hour', 'h': 'hour', 's': 'second', 'sec': 'second'}[m.group(1)]
+            return f'1/{base}'
+
+        # Units with non-pint tokens (e.g. 'uL/min/10^6 cells'): keep as-is.
+        if 'cell' in low:
+            return low
+
+        low = low.replace('^', '**')
+
+        # Compound v4.6 units first, then the simple table (both restore casing,
+        # e.g. 'um' -> 'uM' so micromolar is not read as micrometre).
+        if low in self.compound_unit_mappings:
+            return self.compound_unit_mappings[low]
+        if low in self.unit_mappings:
+            return self.unit_mappings[low]
+
+        return low
     
     def detect_measurement_type(self, unit_str):
         """
@@ -360,11 +412,20 @@ class UnitConverter:
             return 'unknown'
             
         unit_str = str(unit_str).lower()
-        
+
+        # Dimensionless / reporting units.
+        if unit_str in ('ratio', 'fold', '-', 'x', '%', 'percent') or 'cell' in unit_str:
+            return 'dimensionless'
+
+        # Rate / clearance units (per-time, possibly per-mass): check before the
+        # concentration/time heuristics so 'mL/min/kg' is not mislabelled.
+        if re.search(r'/\s*(min|hr|h|sec|s|day)\b', unit_str) or re.fullmatch(r'1/(min|hour|minute|s|second|hr|h)', unit_str):
+            return 'rate'
+
         # Concentration indicators
         if any(x in unit_str for x in ['/ml', '/l', 'm', 'mol']):
             return 'concentration'
-        
+
         # Time indicators
         if any(x in unit_str for x in ['hr', 'min', 'sec', 'day']):
             return 'time'
@@ -422,28 +483,28 @@ class UnitConverter:
             normalized_unit = self.normalize_unit_string(unit_str)
             if not normalized_unit:
                 return value, unit_str, unit_str
-            
+
+            # Reporting/dimensionless units: keep the numeric value unchanged so we
+            # never introduce a scale corruption (e.g. 10-6 cm/s, %, ratio, cells).
+            if normalized_unit in self.keep_as_is_units or 'cell' in normalized_unit:
+                return value, normalized_unit, unit_str
+
             # Create quantity with pint
             try:
                 quantity = value * self.ureg(normalized_unit)
-            except:
-                # Try with original unit string
-                try:
-                    quantity = value * self.ureg(unit_str)
-                except:
-                    logger.warning(f"Could not parse unit: {unit_str}. Returning original value.")
-                    return value, unit_str, unit_str
-            
+            except Exception:
+                logger.warning(
+                    f"Could not parse unit '{unit_str}' (normalized '{normalized_unit}'). "
+                    f"Keeping original value unconverted.")
+                return value, unit_str, unit_str
+
             # Convert to SI
             si_quantity = quantity.to_base_units()
-            
-            # Get SI unit string
             si_unit_str = str(si_quantity.units)
-            
             return float(si_quantity.magnitude), si_unit_str, unit_str
-            
+
         except Exception as e:
-            logger.warning(f"Error converting {value} {unit_str} to SI: {e}")
+            logger.warning(f"Error converting {value} {unit_str} to SI: {e}. Keeping original value.")
             return value, unit_str, unit_str
     
     def convert_column_to_si(self, df, value_col, unit_col, new_value_col=None, new_unit_col=None):
@@ -476,9 +537,11 @@ class UnitConverter:
         if new_unit_col is None:
             new_unit_col = f"{unit_col}_si"
         
-        # Initialize new columns
-        df[new_value_col] = df[value_col].copy()
-        df[new_unit_col] = df[unit_col].copy()
+        # Initialize new columns as object dtype so per-row float/str assignment
+        # works under pandas 3.0 (value_col is often cast to str upstream, and a
+        # str-dtype column rejects float assignment).
+        df[new_value_col] = df[value_col].astype(object)
+        df[new_unit_col] = df[unit_col].astype(object)
         
         # Track conversion statistics
         converted_count = 0
@@ -496,8 +559,8 @@ class UnitConverter:
                 # Try to convert to numeric if it's a string
                 try:
                     if isinstance(value, str):
-                        # Remove comparison operators if present
-                        value = re.sub(r'^[<>]\s*', '', value)
+                        # Remove comparison operators if present (>, >=, <, <=)
+                        value = re.sub(r'^[<>]=?\s*', '', value)
                         value = float(value)
                 except:
                     continue
@@ -909,9 +972,10 @@ class pHCorrector:
             }
             new_cols = [f"{activity_col}_pH_corrected_{method_suffix[self.method]}"]
         
-        # Initialize new columns
+        # Initialize new columns as object dtype so per-row float assignment works
+        # under pandas 3.0 (activity_col is often str-typed upstream).
         for col in new_cols:
-            df[col] = df[activity_col].copy()
+            df[col] = df[activity_col].astype(object)
         
         corrected_count = 0
         total_count = 0
@@ -1001,49 +1065,133 @@ def process_smiles_batch_global(smiles_batch):
     return results
 
 
+def _parse_bracket_numbers(cell):
+    """Parse a Permeability cell into a list of floats/None.
+
+    Accepts bracketed lists like '[6,2]', '[6,]', '[,2]', plain scalars '6.2',
+    or empty/placeholder values. An empty slot (e.g. the '' in '[6,]') becomes
+    None so directional presence is preserved.
+    """
+    if cell is None:
+        return []
+    s = str(cell).strip()
+    if s in ("", "-", "nan", "NaN", "None", "Not specified"):
+        return []
+    s = s.strip("[]")
+    if s == "":
+        return []
+    out = []
+    for part in s.split(","):
+        part = part.strip()
+        if part == "":
+            out.append(None)
+            continue
+        part = re.sub(r'^[<>]=?\s*', '', part)  # tolerate leading comparators
+        try:
+            out.append(float(part))
+        except ValueError:
+            out.append(None)
+    return out
+
+
+def parse_permeability_pair(atob_cell, btoa_cell):
+    """Return (AtoB, BtoA) floats from the two Permeability value columns.
+
+    Handles the v4.6 '[Value, Value]=[AB, BA]' convention whether the pair is
+    split across the AtoB/BtoA columns or carried as a full list in either one.
+    Missing directions come back as None.
+    """
+    ab = _parse_bracket_numbers(atob_cell)
+    ba = _parse_bracket_numbers(btoa_cell)
+    atob = ab[0] if len(ab) >= 1 else None
+    btoa = ba[1] if len(ba) >= 2 else (ba[0] if len(ba) == 1 else None)
+    # Fall back to the other column if one carries the full [AB, BA] pair.
+    if atob is None and len(ba) >= 1:
+        atob = ba[0]
+    if btoa is None and len(ab) >= 2:
+        btoa = ab[1]
+    return atob, btoa
+
+
 class DataInspector:
     def __init__(self,
                  input_path:str,
                  smiles_column:str='SMILES_Structure_Parent',
                  activity_column:str='Measurement_Value',
-                 condition_columns:list=['Test', 'Test_Type', 'Test_Subject', 'Measurment_Type', 'Measurement_Conc', 'Measurement_Temp', 'Measurement_Class']
+                 condition_columns:list=['Test', 'Test_Type', 'Test_Subject', 'Measurement_Type', 'Measurement_Conc', 'Measurement_Temp', 'Measurement_Class', 'Measurement_Route', 'Measurement_Sex', 'Measurement_Formulation']
                  ):
         self.smiles_col = smiles_column
         self.activity_col = activity_column
         self.condition_columns = condition_columns
+        self.is_human_pk = False
         self.df = self.load_data(input_path)
     
+    # Canonical column names keyed by their normalized form (lowercased, trailing
+    # '*' and surrounding whitespace stripped). Covers the v4.6 spelling, the
+    # legacy 'Measurment_*' typo, the 'Test_Species' -> 'Test_Subject' rename, and
+    # VIVO's lowercase 'Measurement_value'. Case-insensitivity is what fixes B1/B4/H5.
+    CANONICAL_COLUMNS = {
+        'chemical id': 'Chemical ID',
+        'chemical name': 'Chemical Name',
+        'smiles_structure_parent': 'SMILES_Structure_Parent',
+        'smiles_salt': 'SMILES_Salt',
+        'test': 'Test',
+        'test_type': 'Test_Type',
+        'test_subject': 'Test_Subject',
+        'test_species': 'Test_Subject',          # legacy rename
+        'test_dose': 'Test_Dose',
+        'measurement_type': 'Measurement_Type',
+        'measurment_type': 'Measurement_Type',   # legacy typo
+        'measurement_relation': 'Measurement_Relation',
+        'measurment_relation': 'Measurement_Relation',
+        'measurement_value': 'Measurement_Value',
+        'measurment_value': 'Measurement_Value',
+        'measurement_value(atob)': 'Measurement_Value(AtoB)',
+        'measurement_value(btoa)': 'Measurement_Value(BtoA)',
+        'measurement_unit': 'Measurement_Unit',
+        'measurment_unit': 'Measurement_Unit',
+        'measurement_conc': 'Measurement_Conc',
+        'measurement_temp': 'Measurement_Temp',
+        'measurement_condition': 'Measurement_Condition',
+        'measurment_condition': 'Measurement_Condition',
+        'measurement_class': 'Measurement_Class',
+        'measurement_route': 'Measurement_Route',
+        'measurement_sex': 'Measurement_Sex',
+        'measurement_formulation': 'Measurement_Formulation',
+        'comment': 'Comment',
+    }
+
     def normalize_column_names(self, df):
         """
-        Normalize column names to handle both old and new K-MELLODDY formats.
-        Maps new format column names to old format for compatibility.
+        Normalize column names to canonical K-MELLODDY names.
+
+        Handles v4.6 (`Measurement_*`), the legacy typo (`Measurment_*`), the
+        `Test_Subject*`/`Test_Species` variants and VIVO's lowercase
+        `Measurement_value` via case-insensitive canonicalization. The real value
+        column is preserved; the legacy `Unnamed: 10` remap is applied only as a
+        fallback when no `Measurement_Value` is present (old merged-cell layout).
         """
-        # Remove the original Measurement_Value column that contains [Value] placeholders
-        if 'Measurement_Value' in df.columns:
-            df = df.drop(columns=['Measurement_Value'])
-        
-        column_mapping = {
-            # Handle Test_Subject variations
-            'Test_Subject*': 'Test_Subject',
-            
-            # Handle Measurement vs Measurment typos (only for old format)
-            # Note: New format uses correct spelling 'Measurement_*'
-            
-            # Map the actual data column in new format
-            'Unnamed: 10': 'Measurement_Value',  # This contains the actual measurement values
-            
-            # Handle new columns that don't exist in old format
-            'Measurement_Conc': 'Measurement_Conc',  # Keep as is for new features
-            'Measurement_Temp': 'Measurement_Temp',  # Keep as is for new features
-            'Measurement_Class': 'Measurement_Class',  # Keep as is for new features
-        }
-        
-        # Apply column mapping
-        df = df.rename(columns=column_mapping)
-        
-        # Remove any unnamed columns that might cause issues (except the one we mapped)
+        rename_map = {}
+        for col in df.columns:
+            key = str(col).strip().rstrip('*').strip().lower()
+            canonical = self.CANONICAL_COLUMNS.get(key)
+            if canonical and canonical != col:
+                rename_map[col] = canonical
+        if rename_map:
+            df = df.rename(columns=rename_map)
+
+        # Drop duplicate columns produced by renaming (keep the first occurrence).
+        df = df.loc[:, ~df.columns.duplicated()]
+
+        # Legacy fallback: some old Excel exports carried the real numbers in an
+        # 'Unnamed: 10' column next to a placeholder value column. Only use it when
+        # a real Measurement_Value did not survive canonicalization.
+        if 'Measurement_Value' not in df.columns and 'Unnamed: 10' in df.columns:
+            df = df.rename(columns={'Unnamed: 10': 'Measurement_Value'})
+
+        # Remove any remaining unnamed columns.
         df = df.loc[:, ~df.columns.str.contains('^Unnamed')]
-        
+
         logger.info(f"Normalized column names. Final columns: {df.columns.tolist()}")
         return df
     
@@ -1063,7 +1211,30 @@ class DataInspector:
             # Read both ADMET and PK sheets if they exist
             excel_file = pd.ExcelFile(input_path)
             sheets = excel_file.sheet_names
-            
+
+            # Human PK: wide-format, 3-row header (real header at row index 2),
+            # separate table sheets, and a non-GIST schema. Load the raw tables
+            # without ADMET-style normalization; the caller routes it to a
+            # separate output.
+            human_pk_sheets = [s for s in sheets
+                               if str(s).startswith('데이터') and 'human pk' in str(s).lower()]
+            if human_pk_sheets:
+                self.is_human_pk = True
+                logger.warning(
+                    "Human PK workbook detected (sheets: %s). Human PK is a "
+                    "wide-format, non-GIST schema; loading raw table without "
+                    "endpoint mapping.", ", ".join(human_pk_sheets))
+                hpk_dfs = [pd.read_excel(excel_file, sheet_name=s, header=2).fillna("Not specified")
+                           for s in human_pk_sheets]
+                df = pd.concat(hpk_dfs, ignore_index=True)
+                df = df.loc[:, ~df.columns.duplicated()]
+                df = self._map_human_pk_smiles(df)
+                for col in df.columns:
+                    if df[col].dtype == 'object' or pd.api.types.is_string_dtype(df[col].dtype):
+                        df[col] = df[col].astype(str).str.replace('μ', 'u')
+                        df[col] = df[col].apply(lambda x: self._replace_special_chars(x) if isinstance(x, str) else x)
+                return df
+
             dfs = []
             if 'ADMET' in sheets:
                 logger.info("Reading ADMET sheet")
@@ -1121,13 +1292,60 @@ class DataInspector:
                 
         # Normalize column names to handle both old and new formats
         df = self.normalize_column_names(df)
-        
+
+        # Permeability: split AtoB/BtoA list values into a usable value column.
+        df = self._expand_permeability_columns(df)
+
         # Ensure all condition columns exist
         for col in self.condition_columns:
             if col not in df.columns:
                 logger.warning(f"Condition column '{col}' not found in data. Creating empty column.")
                 df[col] = "Not specified"
-                
+
+        return df
+
+    def _map_human_pk_smiles(self, df):
+        """Rename the Human PK SMILES column (e.g. 'Substance\\n (약물, SMILES)')
+        to the canonical SMILES column so schema validation passes."""
+        if self.smiles_col in df.columns:
+            return df
+        for col in df.columns:
+            if 'smiles' in str(col).lower():
+                df = df.rename(columns={col: self.smiles_col})
+                logger.info(f"Human PK: mapped SMILES column '{col}' -> '{self.smiles_col}'.")
+                break
+        return df
+
+    def _expand_permeability_columns(self, df):
+        """Turn Permeability's ``Measurement_Value(AtoB)``/``(BtoA)`` list columns
+        into a scalar ``Measurement_Value`` (AtoB = the primary permeability value)
+        plus a ``Measurement_EffluxRatio`` helper (BtoA/AtoB) for GIST derivation.
+        """
+        ab_col, ba_col = 'Measurement_Value(AtoB)', 'Measurement_Value(BtoA)'
+        if ab_col not in df.columns and ba_col not in df.columns:
+            return df
+        atob_vals, btoa_vals, ratio_vals = [], [], []
+        for _, row in df.iterrows():
+            atob, btoa = parse_permeability_pair(row.get(ab_col), row.get(ba_col))
+            atob_vals.append(atob)
+            btoa_vals.append(btoa)
+            if atob not in (None, 0) and btoa is not None:
+                ratio_vals.append(btoa / atob)
+            else:
+                ratio_vals.append(None)
+        if 'Measurement_Value' not in df.columns:
+            df['Measurement_Value'] = atob_vals
+        else:
+            existing = df['Measurement_Value']
+            df['Measurement_Value'] = [
+                a if (pd.isna(e) or str(e) in ("", "Not specified")) else e
+                for e, a in zip(existing, atob_vals)
+            ]
+        df['Measurement_Value_BtoA'] = btoa_vals
+        df['Measurement_EffluxRatio'] = ratio_vals
+        n = sum(1 for v in atob_vals if v is not None)
+        logger.info(f"Permeability columns expanded: {n} AtoB values, "
+                    f"{sum(1 for v in ratio_vals if v is not None)} efflux ratios derived.")
         return df
     
     def _replace_special_chars(self, text):
@@ -1198,9 +1416,15 @@ class DataInspector:
             total_count = len(each_df)
             
             if 'Measurement_Relation' in each_df.columns:
-                uncensored_count = len(each_df[~each_df['Measurement_Relation'].isin(['>', '<'])])
+                # Censored = {>, >=, <, <=}. Equality is stored as the quoted
+                # literal '"="' in v4.6, so strip quotes before comparing; '=' and
+                # blanks count as uncensored.
+                rel_norm = (each_df['Measurement_Relation'].astype(str)
+                            .str.strip().str.strip('"').str.strip("'").str.strip())
+                censored_mask = rel_norm.isin(['>', '>=', '<', '<='])
+                uncensored_count = int((~censored_mask).sum())
             else:
-                has_relation_mask = each_df[self.activity_col].astype(str).str.contains('^[<>]')
+                has_relation_mask = each_df[self.activity_col].astype(str).str.contains(r'^[<>]=?')
                 uncensored_count = len(each_df[~has_relation_mask])
                 
             if total_count < 50 or uncensored_count < 25:
@@ -1583,8 +1807,16 @@ class Preprocessor:
             if self.detect_outliers:
                 self.detect_outlier_from_distribution()
                 
-            # Apply scaling (numeric only)
-            if np.issubdtype(labels.dtype, np.number) or labels.str.match(r'^[<>]?\s*\d+\.?\d*$').any():
+            # Apply scaling (numeric only). Use the pandas dtype API: under
+            # pandas 3.0 np.issubdtype(StringDtype, np.number) raises.
+            is_numeric = pd.api.types.is_numeric_dtype(labels)
+            has_numeric_strings = False
+            if not is_numeric:
+                try:
+                    has_numeric_strings = labels.astype(str).str.match(r'^[<>]?=?\s*\d+\.?\d*$').any()
+                except Exception:
+                    has_numeric_strings = False
+            if is_numeric or has_numeric_strings:
                 self.scale_experiment_values(labels)
             
             # Convert continuous values -> classification (using threshold)
@@ -1596,6 +1828,49 @@ class Preprocessor:
             # Add the base column to the final column list
             if self.activity_col not in self.final_cols:
                 self.final_cols.append(self.activity_col)
+
+    def _infer_ph_column(self):
+        """Infer a per-row pH value from v4.6 locations, in priority order:
+        dedicated pH columns, Test_Subject ('pH7.4'), Measurement_Condition
+        (bare number or 'pH x'), then Test_Type. Returns a float Series (NaN where
+        no pH is present)."""
+        ph_pattern = re.compile(r"pH\s*([0-9]+(?:\.[0-9]+)?)", flags=re.IGNORECASE)
+
+        def _ph_from_text(text):
+            m = ph_pattern.search(str(text))
+            if m:
+                try:
+                    return float(m.group(1))
+                except ValueError:
+                    return None
+            return None
+
+        def _bare_ph(text):
+            m = re.fullmatch(r"\s*([0-9]+(?:\.[0-9]+)?)\s*", str(text))
+            if m:
+                try:
+                    v = float(m.group(1))
+                    if 0.0 <= v <= 14.0:
+                        return v
+                except ValueError:
+                    return None
+            return None
+
+        inferred = pd.Series(np.nan, index=self.df.index, dtype=float)
+        for col in ['pH', 'pH_Value', 'Measurement_pH', 'Test_pH']:
+            if col in self.df.columns:
+                inferred = inferred.combine_first(pd.to_numeric(self.df[col], errors='coerce'))
+        if 'Test_Subject' in self.df.columns:
+            inferred = inferred.combine_first(
+                pd.to_numeric(self.df['Test_Subject'].apply(_ph_from_text), errors='coerce'))
+        if 'Measurement_Condition' in self.df.columns:
+            mc = self.df['Measurement_Condition'].apply(
+                lambda x: _ph_from_text(x) if _ph_from_text(x) is not None else _bare_ph(x))
+            inferred = inferred.combine_first(pd.to_numeric(mc, errors='coerce'))
+        if 'Test_Type' in self.df.columns:
+            inferred = inferred.combine_first(
+                pd.to_numeric(self.df['Test_Type'].apply(_ph_from_text), errors='coerce'))
+        return inferred
 
     def preprocess(self):
         compounds = self.df[self.smiles_col]
@@ -1631,59 +1906,18 @@ class Preprocessor:
                 logger.info("Continuing without unit conversion")
         
         # Perform pH correction if enabled and pH-related data exists
-        if self.correct_pH and 'Test_Type' in self.df.columns:
-            # Check if any Test_Type contains 'pH'
-            pH_data_mask = self.df['Test_Type'].astype(str).str.contains('pH', case=False, na=False)
-            
+        if self.correct_pH:
+            # Build a unified pH source column from several v4.6 locations in
+            # priority order: dedicated pH columns -> Test_Subject ('pH7.4') ->
+            # Measurement_Condition (bare number or 'pH x') -> Test_Type embedded.
+            inferred_pH = self._infer_ph_column()
+            pH_data_mask = inferred_pH.notna()
+
             if pH_data_mask.any():
-                logger.info("pH-related data detected. Starting pH correction...")
+                logger.info(f"pH source detected for {int(pH_data_mask.sum())} rows. Starting pH correction...")
                 try:
-                    # Find pH column (could be named differently)
-                    pH_col = None
-                    possible_pH_cols = ['pH', 'pH_Value', 'Measurement_pH', 'Test_pH']
-                    for col in possible_pH_cols:
-                        if col in self.df.columns:
-                            pH_col = col
-                            break
-                    
-                    if pH_col is None:
-                        # Attempt to infer pH from Test_Type like "..._pH4.0" or strings containing "pH 4.0"
-                        inferred_col = 'inferred_pH'
-                        try:
-                            # Initialize with NaN
-                            self.df[inferred_col] = np.nan
-                            # Extract pH using regex; supports formats: pH4, pH4.0, pH 4.0
-                            # Also handles embedded tokens like "Solubility_pH4.0"
-                            pattern = re.compile(r"pH\s*([0-9]+(?:\.[0-9]+)?)", flags=re.IGNORECASE)
-                            def _extract_ph(text: Any) -> Optional[float]:
-                                s = str(text)
-                                m = pattern.search(s)
-                                if m:
-                                    try:
-                                        return float(m.group(1))
-                                    except Exception:
-                                        return None
-                                # Handle underscore-separated tokens ending with pH number (e.g., _pH4.0)
-                                # General fallback: split on non-alnum and look for tokens starting with 'ph'
-                                tokens = re.split(r"[^A-Za-z0-9\.]+", s)
-                                for tok in tokens:
-                                    if tok.lower().startswith('ph'):
-                                        num = tok[2:]
-                                        if num:
-                                            try:
-                                                return float(num)
-                                            except Exception:
-                                                continue
-                                return None
-                            # Apply only to pH-related rows
-                            self.df.loc[pH_data_mask, inferred_col] = self.df.loc[pH_data_mask, 'Test_Type'].apply(_extract_ph)
-                            if self.df.loc[pH_data_mask, inferred_col].notna().any():
-                                pH_col = inferred_col
-                                logger.info("Inferred pH values from Test_Type; proceeding with pH correction.")
-                            else:
-                                logger.warning("pH column not found and could not infer from Test_Type. pH correction will be skipped.")
-                        except Exception as infer_err:
-                            logger.warning(f"Failed to infer pH from Test_Type: {infer_err}. pH correction will be skipped.")
+                    self.df['inferred_pH'] = inferred_pH
+                    pH_col = 'inferred_pH'
                     if pH_col is not None:
                         logger.info(f"Using pH column: {pH_col}")
                         
@@ -1746,20 +1980,22 @@ class Preprocessor:
         if not self.keep_duplicates and not is_pk_data:
             # Record data count before duplicate removal
             before_count = len(self.df)
-            
+
+            # Keep a copy so we can recover WITHOUT losing enriched columns
+            # (_si, pH_corrected, Chemical ID) if the strict dedup empties the set.
+            df_before_dedup = self.df.copy()
+
             # Remove duplicates (remove all duplicates with keep=False)
             self.df.drop_duplicates(subset=["Standardized_SMILES"], keep=False, inplace=True, ignore_index=True)
-            
+
             # Record data count after duplicate removal
             after_count = len(self.df)
             if after_count == 0 and before_count > 0:
                 logger.warning(f"All data removed during duplicate removal! Original count: {before_count}")
-                # Try again with keep='first' to prevent complete data removal
-                self.df = pd.DataFrame(compounds).reset_index(drop=True)
-                self.df[self.activity_col] = labels.reset_index(drop=True)
-                self.preprocess_compounds(compounds)
-                self.preprocess_labels(labels)
-                self.df.drop_duplicates(subset=["Standardized_SMILES"], keep='first', inplace=True, ignore_index=True)
+                # Recover from the pre-dedup frame with keep='first' so all columns
+                # (including pH/SI-derived ones) survive.
+                self.df = df_before_dedup.drop_duplicates(
+                    subset=["Standardized_SMILES"], keep='first', ignore_index=True)
                 logger.info(f"Recovered {len(self.df)} records using keep='first' strategy")
             else:
                 logger.info(f"Removed {before_count - after_count} duplicate records. Remaining: {after_count}")
@@ -1774,8 +2010,14 @@ class Preprocessor:
             logger.error("Preprocessing resulted in empty dataset!")
         else:
             logger.info(f"Preprocessing completed. Final dataset contains {len(self.df)} records.")
-                
-        return self.df[self.final_cols]
+
+        # Select only columns that survived processing (dedup recovery paths can
+        # rebuild self.df and drop some expected columns); warn rather than crash.
+        existing_cols = [c for c in dict.fromkeys(self.final_cols) if c in self.df.columns]
+        missing_cols = [c for c in dict.fromkeys(self.final_cols) if c not in self.df.columns]
+        if missing_cols:
+            logger.warning(f"Output is missing {len(missing_cols)} expected column(s): {missing_cols}")
+        return self.df[existing_cols]
 
 class DataVisualizer:
     """
@@ -2306,6 +2548,22 @@ if __name__ == "__main__":
             )
             df = inspector.df.copy()
 
+            # Human PK is a wide-format, non-GIST schema: write it out separately
+            # instead of forcing it through endpoint mapping (which would yield an
+            # empty/garbage matrix).
+            if getattr(inspector, "is_human_pk", False):
+                base = os.path.splitext(os.path.basename(args.input_path))[0]
+                out_dir = "./processed_data"
+                os.makedirs(out_dir, exist_ok=True)
+                hpk_path = os.path.join(out_dir, f"{base}_HumanPK.csv")
+                df.to_csv(hpk_path, index=False)
+                logger.warning(
+                    "Human PK detected: wrote raw wide-format table to %s and "
+                    "skipped GIST matrix conversion (not a GIST-mappable schema).",
+                    hpk_path)
+                logger.info("Finished GIST matrix conversion")
+                sys.exit(0)
+
             # Normalize critical column names presence
             smiles_col = args.smiles_col if args.smiles_col in df.columns else "SMILES_Structure_Parent"
             unit_col = "Measurement_Unit" if "Measurement_Unit" in df.columns else None
@@ -2364,8 +2622,33 @@ if __name__ == "__main__":
             else:
                 value_col = args.activity_col
 
+            # H6: qualitative results (Ames/Genetoxicity) store Positive/Negative
+            # in Measurement_Unit with a '-' value. Encode as 1.0/0.0 before the
+            # numeric coercion so they are not dropped.
+            if "Measurement_Unit" in df.columns:
+                unit_lower = df["Measurement_Unit"].astype(str).str.strip().str.lower()
+                qual_mask = unit_lower.isin(["positive", "negative"])
+                if qual_mask.any():
+                    df.loc[qual_mask, value_col] = unit_lower[qual_mask].map(
+                        {"positive": 1.0, "negative": 0.0})
+                    logger.info(f"Encoded {int(qual_mask.sum())} qualitative "
+                                f"Positive/Negative results as 1/0.")
+
             # Ensure numeric type for aggregation (handle strings like '3.218e-05' or non-numeric leftovers)
             df[value_col] = pd.to_numeric(df[value_col], errors='coerce')
+
+            # Permeability: derive Efflux_ratio (BtoA/AtoB) rows. The ratio is
+            # dimensionless (both directions share the unit) so it is injected
+            # directly without SI conversion.
+            if 'Measurement_EffluxRatio' in df.columns:
+                ratio_num = pd.to_numeric(df['Measurement_EffluxRatio'], errors='coerce')
+                er_mask = ratio_num.notna()
+                if er_mask.any():
+                    er = df.loc[er_mask].copy()
+                    er['gist_endpoint'] = 'Efflux_ratio'
+                    er[value_col] = ratio_num.loc[er_mask].values
+                    df = pd.concat([df, er], ignore_index=True)
+                    logger.info(f"Injected {int(er_mask.sum())} Efflux_ratio rows from Permeability BtoA/AtoB.")
 
             # Load GIST column list (tab-separated, first line)
             gist_file = os.path.join(os.path.dirname(__file__), "gist", "gist_format.txt")
@@ -2374,6 +2657,27 @@ if __name__ == "__main__":
             gist_cols = [c for c in first_line.split("\t") if c]
             if not gist_cols:
                 raise RuntimeError("GIST endpoint list is empty. Check gist_format.txt")
+
+            # M1/M2: rows whose endpoint has no GIST target would be silently
+            # dropped by the pivot. Instead report them and write to a separate
+            # *_unmapped.csv so the loss is visible (e.g. Cytotoxicity,
+            # Genetoxicity, pKa/MW, Phase-II metabolism, many VIVO params).
+            gist_set = set(gist_cols)
+            unmapped_mask = ~df["gist_endpoint"].isin(gist_set)
+            if unmapped_mask.any():
+                unmapped_df = df.loc[unmapped_mask]
+                counts = unmapped_df["endpoint_canonical"].value_counts()
+                logger.warning(
+                    "%d row(s) across %d endpoint(s) have no GIST target and are "
+                    "excluded from the matrix: %s",
+                    int(unmapped_mask.sum()), len(counts),
+                    ", ".join(f"{ep!r}x{int(n)}" for ep, n in counts.head(20).items()))
+                out_dir = "./processed_data"
+                os.makedirs(out_dir, exist_ok=True)
+                um_base = os.path.basename(args.input_path).split('.')[0]
+                um_path = os.path.join(out_dir, f"{um_base}_unmapped.csv")
+                unmapped_df.to_csv(um_path, index=False)
+                logger.warning("Wrote %d unmapped rows to %s", len(unmapped_df), um_path)
 
             # Detect PK rows (patient-origin) heuristics
             def is_pk_row(row: pd.Series) -> bool:
@@ -2487,7 +2791,19 @@ if __name__ == "__main__":
             smiles_column=args.smiles_col,
             activity_column=args.activity_col
         )
-        
+
+        # Human PK is a wide-format, non-GIST schema with no Test/Test_Type task
+        # grouping; write it out separately rather than crash in quorum grouping.
+        if getattr(inspector, "is_human_pk", False):
+            os.makedirs(args.output_path, exist_ok=True)
+            base = os.path.splitext(os.path.basename(args.input_path))[0]
+            hpk_path = os.path.join(args.output_path, f"{base}_HumanPK.csv")
+            inspector.df.to_csv(hpk_path, index=False)
+            logger.warning(
+                "Human PK detected: wrote raw wide-format table to %s and skipped "
+                "task-group processing (not a standard long-format schema).", hpk_path)
+            sys.exit(0)
+
         valid_groups = inspector.process()
         
         if len(valid_groups) < 1:

--- a/llm_converter/src/manual_converter.py
+++ b/llm_converter/src/manual_converter.py
@@ -48,7 +48,12 @@ DEFAULT_ENDPOINT_SYNONYMS: Dict[str, str] = {
     "pgp substrate": "pgp_substrate",
     "p-gp substrate": "pgp_substrate",
     "p-gp inhibitor": "pgp_inhibitor",
+    "p-gp": "pgp_inhibitor",
+    "p_gp": "pgp_inhibitor",
     "bcrp inhibitor": "BCRP",
+    "bcrp": "BCRP",
+    "efflux ratio": "Efflux_ratio",
+    "efflux_ratio": "Efflux_ratio",
     "oatp1b1": "OATP1B1_Inhibitor",
     "oatp1b3": "OATP1B3_Inhibitor",
     "oatp2b1": "OATP2B1_Inhibitor",
@@ -85,6 +90,14 @@ DEFAULT_ENDPOINT_SYNONYMS: Dict[str, str] = {
     "skin irritation": "Skin Reaction",
     "micronucleus": "Micronucleus",
     "fdamdd": "FDAMDD(reg)",
+    # Solubility & lipophilicity
+    "solubility": "Solubility",
+    "lipophilicity": "Lipophilicity",
+    "logp": "Lipophilicity",
+    "log p": "Lipophilicity",
+    "clogp": "Lipophilicity",
+    "alogp": "Lipophilicity",
+    "logd": "Lipophilicity",
     # Misc
     "plasma protein binding": "PPBR",
     "ppb": "PPBR",
@@ -117,9 +130,19 @@ class ManualConversionConfig:
 class ManualFormatConverter:
     """Endpoint converter using deterministic heuristics."""
 
+    # CYP isoforms that actually have a GIST column (as *_Inhibitor / *_Substrate).
+    # CYP1A1 and CYP2C8 appear in v4.6 data but have NO GIST slot, so they must be
+    # left unmapped rather than bleeding into a neighbouring isoform via similarity.
+    CYP_GIST_ISOFORMS = frozenset({"cyp1a2", "cyp2b6", "cyp2c9", "cyp2c19", "cyp2d6", "cyp3a4"})
+
+    # Endpoints present in v4.6 but with NO GIST column: never force-map them via
+    # token/similarity (they belong in the *_unmapped.csv report instead).
+    UNMAPPABLE_TOKENS = frozenset({"cytotoxicity", "genetoxicity"})
+
     def __init__(self, config: Optional[ManualConversionConfig] = None):
         self.config = config or ManualConversionConfig()
         self.gist_endpoints = self._load_gist_endpoints()
+        self._gist_set = set(self.gist_endpoints)
         self._normalized_gist = {
             endpoint: self._normalize(endpoint) for endpoint in self.gist_endpoints
         }
@@ -227,6 +250,35 @@ class ManualFormatConverter:
 
         return None
 
+    @staticmethod
+    def _contiguous_index(key_tokens: Tuple[str, ...], tokens: Tuple[str, ...]) -> int:
+        """Return the start index of key_tokens as a contiguous sublist of tokens,
+        or -1 if absent. Word-boundary matching (a whole-token sequence), so short
+        keys like 'tr'/'gr' no longer substring-match inside 'transporter'."""
+        n, m = len(tokens), len(key_tokens)
+        if m == 0 or m > n:
+            return -1
+        for i in range(n - m + 1):
+            if tokens[i:i + m] == key_tokens:
+                return i
+        return -1
+
+    def _cyp_guard(self, normalized: str) -> Optional[str]:
+        """Map CYP endpoints to their exact GIST isoform column, never a neighbour.
+
+        Returns a GIST column name, the sentinel '' (CYP endpoint with no GIST
+        slot -> leave unmapped), or None (not a CYP endpoint)."""
+        isoforms = re.findall(r"cyp\d+[a-z]\d*", normalized)
+        if not isoforms:
+            return None
+        iso = isoforms[0]  # CYP3A4_MDZ / CYP3A4_TST both collapse to 'cyp3a4' here
+        role = "Substrate" if "substrate" in normalized else "Inhibitor"
+        if iso in self.CYP_GIST_ISOFORMS:
+            target = f"{iso.upper()}_{role}"
+            if target in self._gist_set:
+                return target
+        return ""  # CYP1A1 / CYP2C8 etc.: no GIST slot -> unmapped
+
     def match_endpoint(self, endpoint: Any) -> str:
         normalized = self._normalize(endpoint)
         if not normalized:
@@ -234,16 +286,33 @@ class ManualFormatConverter:
 
         tokens = self._tokenize(normalized)
 
+        # CYP guard first: exact isoform only, no cross-isoform similarity bleed.
+        cyp = self._cyp_guard(normalized)
+        if cyp is not None:
+            return cyp if cyp else str(endpoint)
+
         # Direct synonym mapping
         if normalized in self.synonym_map:
             return self.synonym_map[normalized]
 
-        # Partial keyword lookup (token-level)
+        # Endpoints with no GIST slot: leave unmapped (do not force via similarity).
+        if any(tok in self.UNMAPPABLE_TOKENS for tok in tokens):
+            return str(endpoint)
+
+        # Partial keyword lookup via whole-token subsequence matching. Prefer the
+        # most specific match: longest key, then the one that starts latest (the
+        # Measurement_Type is the last, most-discriminating canonical component).
+        best = None  # (num_tokens, start_index, mapped)
         for synonym_key, mapped in self.synonym_map.items():
-            if self.config.prefer_exact and synonym_key == normalized:
-                return mapped
-            if synonym_key in normalized:
-                return mapped
+            key_tokens = tuple(synonym_key.split())
+            idx = self._contiguous_index(key_tokens, tokens)
+            if idx < 0:
+                continue
+            cand = (len(key_tokens), idx, mapped)
+            if best is None or cand[:2] > best[:2]:
+                best = cand
+        if best is not None:
+            return best[2]
 
         # Similarity fallback
         matched = self._match_with_similarity(normalized, tokens)

--- a/valid_options.csv
+++ b/valid_options.csv
@@ -1,48 +1,52 @@
-Test,Test_Type,Test_Species,Measurement_Type,Measurement_Condition,Measurement_Relation,Measurement_value,Measurement_Unit,Comment
-Physicochem,logP,Human,T1/2,,>,,%,
-Solubility,ClogP,Mouse,Remaining,,<,,ratio,
-Permeability,AlogP,Rat,Remaining_30min,,>=,,fold-shift,
-Brain penetration,pKa,Dog,Remaining_60min,,<=,,fold-induction,
-Efflux transporter,Solubility,Monkey,Remaining_120min,,=,,fold,
-Plasma protein binding,Solubility_DW,,Remaining_240min,,~,,M,
-Plasma stability,Solubility_pH7.4,,Clearance,,>>,,mM,
-Metabolic stability,Solubility_pH2.1,,Clint,,<<,,uM,
-CYP Inhibition,Solubility_pH9.0,,Pe,,Positive,,nM,
-CYP Induction,Solubility_pH4.0,,Papp,,Negative,,kg/mL,
-DILI,Solubility_FaSSIF,,Kp,,Toxic,,g/mL,
-Pharmacokinetics,Solubility_FeSSIF,,"Kp,uu",,Non-Toxic,,mg/mL,
-Toxicity,Caco-2,,"fu,p",,Low,,ug/mL,
-,BBB,,Inhibition,,High,,ng/mL,
-,PAMPA,,Ki ,,Moderate,,mL/min/kg,
-,Total brain-to-plasma ratios,,KI,,CNS+,,uL/min/mg,
-,Unbound brain-to-unbound plasma ratios,,kinact,,CNS-,,uL/min/106 cells,
-,PPB,,IC50 fold-shift ,,CNS+/-,,mg/kg,
-,P-gp,,IC50,,Brain penetrant,,L/kg,
-,BCRP,,EC50,,Non-penetrant,,ng.h/mL,
-,Plasma stability,,CC50,,Substrate ,,mg.h/L,
-,Metabolic stability I ,,LD50,,Non-substrate,,year,
-,Metabolic stability II ,,Fold,,Potent,,month,
-,Liver microsomes,,mRNA/ activity ,,Weak,,week,
-,Hepatocytes,,fold-induction,,Inducer,,day,
-,CYP3A,,Emax,,Non-inducer,,hr,
-,CYP3A4,,TA98_S9+,,,,min,
-,CYP3A4-M,,TA98_S9-,,,,Second,
-,CYP3A-MDZ,,TA100_S9+,,,,cm/sec,
-,CYP3A-TST,,TA100_S9-,,,,10-6 cm/s,
-,CYP1A2,,Auc,,,,min-1,
-,CYP2B6,,C0,,,,,
-,CYP2C8,,Cmax,,,,,
-,CYP2C9,,MRT,,,,,
-,CYP2C19,,Tmax,,,,,
-,CYP2D6,,Vd,,,,,
-,hERG,,Vss,,,,,
-,hERG_FP,,F(BA),,,,,
-,hERG_Patch clamp,,,,,,,
-,Cytotoxicity_A549,,,,,,,
-,Cytotoxicity_HepG2,,,,,,,
-,Cytotoxicity_HEK293,,,,,,,
-,Cytotoxicity_Jurkat,,,,,,,
-,Ames,,,,,,,
-,PK_iv,,,,,,,
-,PK_po,,,,,,,
-,PK_ip,,,,,,,
+Test,Test_Type,Test_Subject,Measurement_Type,Measurement_Relation,Measurement_Unit
+Brain_penetration,Ames,,AUCExtra,>,%
+CYP_Inhibition,BBB_PAMPA,Caco-2,AUCinf,>=,-
+Efflux_transporter,BCRP,Dog,AUClast,"""=""",10-6 cm/s
+In_vivo_PK,CYP1A1,E.coli,BA,<=,L/hr/kg
+Metabolic_stability,CYP1A2,HEK293,CC50,<,L/kg
+Permeability,CYP2B6,Hamster,CLhep,,Negative
+Physicochem,CYP2C19,Human,CLint,,Positive
+Plasma_protein_binding,CYP2C8,LLC,Clearance,,h
+Plasma_stability,CYP2C9,MDCK II,Clearance/F,,hour
+Solubility,CYP2D6,MDCK-MDR1,Cmax,,hr
+Toxicity,CYP3A4_MDZ,Monkey,Co,,mL/kg
+,CYP3A4_TST,Mouse,IC50,,mL/min/kg
+,Cytotoxicity,Pig,Inhibition,,min
+,Genetoxicity,Rat,Inhibition_10uM,,nM
+,Hepatocytes,S.typhimurium,Inhibition_1uM,,ng/mL
+,Hepatocytes_Phase_II,,Kp,,ng·h/mL
+,Liver_Microsomes_Phase_II,,Kp_uu,,ratio
+,Liver_microsomes,,MRT,,uL/min/mg
+,PK_ip,,Papp,,uM
+,PK_iv,,Pe,,
+,PK_po,,Remaining_10min,,
+,PK_sc,,Remaining_30min,,
+,P_gp,,Remaining_60min,,
+,Total_BBB,,Rsq,,
+,Unbound_BBB,,SOS Chromotest,,
+,hERG,,T1/2,,
+,,,TA100_S9+,,
+,,,TA100_S9-,,
+,,,TA102_S9+,,
+,,,TA102_S9-,,
+,,,TA1535_S9+,,
+,,,TA1535_S9-,,
+,,,TA1537_S9+,,
+,,,TA1537_S9-,,
+,,,TA97_S9+,,
+,,,TA97_S9-,,
+,,,TA97a_S9+,,
+,,,TA97a_S9-,,
+,,,TA98_S9+,,
+,,,TA98_S9-,,
+,,,Tmax,,
+,,,Vd,,
+,,,Vd/F,,
+,,,Vss,,
+,,,Vz,,
+,,,WP2uvrA(pKM101)_S9+,,
+,,,WP2uvrA(pKM101)_S9-,,
+,,,WP2uvrA_S9+,,
+,,,WP2uvrA_S9-,,
+,,,X,,
+,,,efflux_Ratio,,


### PR DESCRIPTION
K-MELLODDY 표준 데이터 v4.6 포맷을 지원하도록 전처리/GIST 변환 파이프라인을 재작업. 확인된 갭 14건(Blocker 4 / High 6 / Medium 4)을 모두 수정하고 hits-preprocess.py와 data.py 양쪽에 동일 적용(동작 일치 검증).

Blocker:
- B1 normalize_column_names 재작성: 대소문자·오타(Measurment_*)·별표·소문자 (Measurement_value)를 캐노니컬화, 값열 무조건 삭제/Unnamed:10 하드코딩 제거
- B2 Permeability [AB,BA] 리스트 파서 + AtoB->Caco2, Efflux_ratio=BtoA/AtoB 유도
- B3 Human PK(3행헤더/와이드포맷/SMILES 컬럼) 감지 -> 별도 *_HumanPK.csv
- B4 condition_columns 오타 Measurment_Type -> Measurement_Type

High:
- H1 pH를 Test_Subject/Measurement_Condition/Test_Type에서 우선순위 추출
- H2 단위 정규화 재작성: 10-6 cm/s 오염 방지, uM 대소문자 인식, 복합단위/무차원
- H3 CYP 정확 아이소폼 가드(CYP1A1/CYP2C8 미매핑, MDZ/TST->CYP3A4 병합)
- H4 매퍼 tier-2 토큰경계 매칭(tr/gr가 transporter 오탐 차단)
- H5 VIVO 소문자 값 컬럼(B1로 해결)
- H6 정성 Positive/Negative -> 1/0 인코딩

Medium:
- M1 Cytotoxicity/Genetoxicity 강제매핑 금지(UNMAPPABLE_TOKENS)
- M2 미매핑 행 경고 + *_unmapped.csv, logP->Lipophilicity
- M3 검열집합 {>,>=,<,<=} 확장 + "=" 리터럴 정규화
- M4 Route/Sex/Formulation 태스크 그룹핑 반영

부수(pandas 3.0 호환): convert_column_to_si/pHCorrector.correct_column object dtype, np.issubdtype->pd.api.types, dedup 전손 복구 시 컬럼 보존, Descriptors import, data.py 모듈 logger.

참조/문서/테스트:
- valid_options.csv v4.6 어휘 갱신(Test_Species->Test_Subject)
- config 기본 컬럼을 원시입력 컬럼으로 교정
- docs/v46_repro.md(회귀 기준선), docs/v46_gist_mapping.md(매핑표)
- tests/test_v46_regression.py(12개), tests/make_v46_fixtures.py